### PR TITLE
Remove duplicate choices

### DIFF
--- a/cmd/gambling-bot.go
+++ b/cmd/gambling-bot.go
@@ -18,7 +18,7 @@ func main() {
 	// Basic config
 	app.Name = "gambling-bot"
 	app.Usage = "A golang powered Twitch bot handling simple vote mechanism"
-	app.Version = "1.1.0"
+	app.Version = "1.1.1"
 
 	// Flags
 	app.Flags = []cli.Flag{

--- a/internal/app/gambling.go
+++ b/internal/app/gambling.go
@@ -131,6 +131,21 @@ func lower(data []string) []string {
 
 }
 
+// Remove duplicates possibilities
+func filterPossibilities(data []string) []string {
+	var res []string
+	keys := make(map[string]bool)
+
+	for _, e := range data {
+		if _, s := keys[e]; !s {
+			keys[e] = true
+			res = append(res, e)
+		}
+	}
+
+	return res
+}
+
 // Link Twitch events to dedicated functions
 func (g *Gambling) twitchOnEventSetup() {
 	// Message handler, closure, because an access to *Gambling is needed
@@ -340,7 +355,8 @@ func (g *Gambling) handleCreate(user twitch.User, args []string) {
 
 	g.CurrentVote.IsOpen = true
 	g.CurrentVote.Votes = make(map[string]string)
-	g.CurrentVote.Possibilities = lower(args)
+	g.CurrentVote.Possibilities = filterPossibilities(lower(args))
+
 	// Ensure a 500 items long ACK queue
 	g.CurrentVote.Acks = NewAcks()
 

--- a/internal/app/gambling_test.go
+++ b/internal/app/gambling_test.go
@@ -32,6 +32,22 @@ func TestWrongCommand(t *testing.T) {
 
 }
 
+func testFilterPossibilities(t *testing.T) {
+
+	var data = []string{"test", "test", "Test", "choice"}
+	var expected = []string{"test", "choice"}
+
+	res := filterPossibilities(data)
+
+	if res[0] != expected[0] {
+		t.Errorf("[filterPossibilities] Expected : %s, Get %s", expected, res)
+	}
+
+	if len(res) != 2 {
+		t.Errorf("[filterPossibilities] Choices not filtered correctly")
+	}
+}
+
 func TestVote(t *testing.T) {
 	g := &Gambling{
 		CurrentVote: &Vote{


### PR DESCRIPTION
This PR removes duplicates choices and ensure that only one exists. For example, passing `test Test choice` to create command will result in `test` and `choice` as arguments